### PR TITLE
docs: document open-redirect risk in logoutAzure() [#17]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,27 @@
 # OAUTH2 authenticator for AzureAD
 
+## Security considerations
+
+### `logoutAzure($redirectUrl)` — open-redirect risk (severity: Low)
+
+`logoutAzure()` appends `$redirectUrl` directly to the Microsoft
+`post_logout_redirect_uri` query parameter.  Microsoft validates this value
+against the redirect URIs registered for your app, which limits exploitability.
+However, if user-supplied input (e.g. from `$_GET` or `$_POST`) is ever passed
+here, it becomes an open-redirect vector should that Azure-side validation be
+misconfigured or loosened.
+
+**Rule:** always pass a hard-coded or configuration-derived URL — never a
+caller/user-supplied value.
+
+```php
+// CORRECT – value comes from your own configuration
+$authenticator->logoutAzure('https://' . $_SERVER['SERVER_NAME']);
+
+// WRONG – value comes from user input
+$authenticator->logoutAzure($_GET['redirect']);   // ← do not do this
+```
+
 ## Sample
 
 Where config.php sets the global SETTINGS and logger LOG

--- a/src/AzureAuthenticator.php
+++ b/src/AzureAuthenticator.php
@@ -131,8 +131,18 @@ class AzureAuthenticator
   }
 
   /**
-   * Summary of logoutAzure
-   * @param $redirectUrl where to redirect after logout
+   * Redirect the user to the Microsoft logout endpoint and then to the given URL.
+   *
+   * **Security notice:** `$redirectUrl` must be a trusted, application-controlled
+   * value (e.g. a hard-coded URL or one taken from your own configuration).
+   * Never pass a value that originates from user input (`$_GET`, `$_POST`, …).
+   * Although Microsoft validates `post_logout_redirect_uri` against the
+   * registered redirect URIs for the app, passing an unvalidated caller-supplied
+   * value creates an open-redirect vector if that validation is ever loosened or
+   * misconfigured.
+   *
+   * @param string $redirectUrl Trusted URL to redirect to after logout.
+   *                            Must not be derived from user-supplied input.
    * @return never
    */
   public function logoutAzure( string $redirectUrl ): never


### PR DESCRIPTION
## Summary

- Added a **security notice** to the `logoutAzure()` PHPDoc warning callers to never pass user-supplied input as `$redirectUrl`
- Added a **Security considerations** section to `README.md` with a description of the risk, the rule to follow, and correct/incorrect usage examples

## Details

Closes #17

`logoutAzure()` appends `$redirectUrl` directly to Microsoft's `post_logout_redirect_uri`. Microsoft validates this against the app's registered redirect URIs, but passing an unvalidated user-supplied value (e.g. from `$_GET`) would create an open-redirect vector if that validation is ever misconfigured. The fix chosen is the documentation approach from the issue: make the constraint explicit in both the docblock and the README.

## Test plan

- [ ] Read updated docblock in `src/AzureAuthenticator.php`
- [ ] Read the new Security considerations section in `README.md`
- [ ] Verify the sample in README still shows a correct usage (`$_SERVER['SERVER_NAME']`, not user input)

🤖 Generated with [Claude Code](https://claude.com/claude-code)