### PR TITLE
fix: enforce logon_callback before handling authorization code [#12]

### DIFF
--- a/src/AzureAuthenticator.php
+++ b/src/AzureAuthenticator.php
@@ -71,6 +71,10 @@ class AzureAuthenticator
    */
   public function handleAuthorizationCode(): void
   {
+    if( !is_callable( $this->logon_callback ) ) {
+      throw new \LogicException( 'logon_callback must be set via setLogonCallback() before calling handleAuthorizationCode().' );
+    }
+
     if( isset( $_POST[ 'error' ] ) ) {
       $this->handleError( $_POST[ 'error' ] );
     }
@@ -115,16 +119,14 @@ class AzureAuthenticator
       'displayName'       => $userResource[ "displayName" ]
     ] );
 
-    if( is_callable( $this->logon_callback ) ) {
-      if( !call_user_func( $this->logon_callback, $userResource ) ) {
-        $this->logger->alert( 'Logon error', [
-          'userPrincipalName' => $userResource[ 'userPrincipalName' ],
-          'displayName'       => $userResource[ "displayName" ],
-          'id'                => $userResource[ 'id' ]
-        ] );
-        http_response_code( StatusCode::Forbidden->value );
-        exit();
-      }
+    if( !call_user_func( $this->logon_callback, $userResource ) ) {
+      $this->logger->alert( 'Logon error', [
+        'userPrincipalName' => $userResource[ 'userPrincipalName' ],
+        'displayName'       => $userResource[ "displayName" ],
+        'id'                => $userResource[ 'id' ]
+      ] );
+      http_response_code( StatusCode::Forbidden->value );
+      exit();
     }
 
     return true;

--- a/src/GoogleAuthenticator.php
+++ b/src/GoogleAuthenticator.php
@@ -42,6 +42,10 @@ class GoogleAuthenticator
 
   public function handleAuthorizationCode(): void
   {
+    if (!is_callable($this->logon_callback)) {
+      throw new \LogicException('logon_callback must be set via setLogonCallback() before calling handleAuthorizationCode().');
+    }
+
     if (isset($_POST['error'])) {
       $this->handleError($_POST['error']);
     }
@@ -86,15 +90,13 @@ class GoogleAuthenticator
       'name' => $userResource['name']
     ]);
 
-    if (is_callable($this->logon_callback)) {
-      if (!call_user_func($this->logon_callback, $userResource)) {
-        $this->logger->alert('Logon error', [
-          'email' => $userResource['email'],
-          'id' => $userResource['id']
-        ]);
-        http_response_code(StatusCode::Forbidden->value);
-        exit();
-      }
+    if (!call_user_func($this->logon_callback, $userResource)) {
+      $this->logger->alert('Logon error', [
+        'email' => $userResource['email'],
+        'id' => $userResource['id']
+      ]);
+      http_response_code(StatusCode::Forbidden->value);
+      exit();
     }
     return true;
   }


### PR DESCRIPTION
## Summary

- Adds a `\LogicException` guard at the top of `handleAuthorizationCode()` in both `AzureAuthenticator` and `GoogleAuthenticator`
- Removes the now-redundant `is_callable()` wrapper in `processLogon()` — the callback is guaranteed to be set at that point

## Details

Closes #12

Previously `logon_callback` was optional: if `setLogonCallback()` was never called, the `is_callable` guard in `processLogon()` simply skipped the check and returned `true`, silently accepting every authenticated Azure AD / Google account. This is a critical security gap.

The fix fails loudly at the earliest safe point (`handleAuthorizationCode()` entry) with a programmer-error exception, making it impossible to accidentally ship an unauthenticated flow.

## Test plan

- [ ] Call `handleAuthorizationCode()` without setting a callback → expect `\LogicException`
- [ ] Call `handleAuthorizationCode()` with a callback that returns `false` → expect 403 / exit
- [ ] Call `handleAuthorizationCode()` with a callback that returns `true` → expect redirect to `/`
- [ ] Verify both `AzureAuthenticator` and `GoogleAuthenticator` behave identically

🤖 Generated with [Claude Code](https://claude.com/claude-code)